### PR TITLE
[PGM] 연속 부분 수열 합의 개수  / Level 2 / 50분

### DIFF
--- a/dongmin/연속 부분 수열 합의 개수.js
+++ b/dongmin/연속 부분 수열 합의 개수.js
@@ -1,0 +1,13 @@
+function solution(elements) {
+  const sumAll = elements.reduce((a, b) => a + b);
+  const answer = new Set();
+
+  for (let i = 1; i <= elements.length; i += 1) {
+    for (let j = 0; j + i <= elements.length; j += 1) {
+      const newArrSum = elements.slice(j, j + i).reduce((a, b) => a + b);
+      answer.add(newArrSum);
+      sumAll - newArrSum && answer.add(sumAll - newArrSum);
+    }
+  }
+  return answer.size;
+}


### PR DESCRIPTION
만약 배열이 `[1, 2, 3, 4, 5]` 라면,

길이가 1인 배열로 잘라낸 `[1]` 의 합과 나머지 `[2, 3, 4, 5]`의 합을 정답 배열에 추가,
이어서 `[2]` 의 합과 나머지 `[1, 3, 4, 5]`의 합을 정답 배열에 추가, ... `[5]` 까지 이어서 반복

길이가 2인 배열로 잘라낸 `[1, 2]` 의 합과 나머지 `[3, 4, 5]` 의 합을 정답 배열에 추가 ,
이어서 `[2, 3]` 의 합과 나머지 `[1, 4, 5]`의 합을 정답 배열에 추가, ,,, `[4, 5]` 까지 이어서 반복

...

이렇게 길이가 5인 배열의 합까지 담아 중복 제거 처리를 하는 식으로 계산했습니다!
`for`문을 이중으로 쓰고 안에서 `reduce`까지 사용하니 성능은 처참합니다 ㅜㅜ

