### PR TITLE
[PGM] [1차] 뉴스 클러스터링 / Level 2 / 60분+

### DIFF
--- a/Kled/[1차] 뉴스 클러스터링.js
+++ b/Kled/[1차] 뉴스 클러스터링.js
@@ -1,0 +1,37 @@
+function solution(str1, str2) {
+    // 소문자 및 대문자 알파벳 허용, + 를 통해 연속적인 알파벳만 허용
+    const rString = /^[a-zA-Z]+$/;
+    const THRESHOLD = 65536;
+    
+    const clustering = (str) => {
+        const arr = [];
+        const lower = str.toLowerCase();
+        
+        for (let i = 0; i < lower.length - 1; i += 1) {
+            const value = lower.slice(i, i + 2);
+
+            // 영문자로 된 글자 쌍만 허용
+            if (rString.test(value)) arr.push(value);
+        }
+        
+        return arr
+    }
+    
+    const cluster1 = clustering(str1)
+    const cluster2 = clustering(str2)
+    
+    const union = cluster1.length + cluster2.length
+    const intersection = cluster1.filter(value => {
+        const index = cluster2.indexOf(value);
+      
+        if (index !== -1) {
+            cluster2.splice(index, 1);
+            return true; 
+        }
+    }).length;
+  
+    // 두 문자열 모두 유효하지 않을 때
+    if (!union) return THRESHOLD;
+    
+    return Math.trunc(intersection * THRESHOLD / (union - intersection))
+}


### PR DESCRIPTION
1. 교집합을 구하는 로직에서 도움을 받았습니다. 원소의 중복을 허용한다고 했지, 교집합에서까지 중복을 허용하지는 않았던 것을 이해하지 못했었네요. 

```js
cluster2.splice(index, 1);
```

---

2. 식 중간에 합집합을 뜻하는 `union` 변수가 자그마한 오류가 있습니다.

```js
const union = cluster1.length + cluster2.length
```

합집합은 사실 `A + B - A ∩ B`이지만, 순서상 `A ∩ B`를 구하는 과정이 이후의 로직이었기에 귀엽게 넘어가주세요.

