### PR TITLE
[PGM] 스킬트리 / Level 2 / 15분

### DIFF
--- a/dongmin/스킬트리.js
+++ b/dongmin/스킬트리.js
@@ -1,0 +1,15 @@
+function solution(skills, skill_trees) {
+  let answer = 0;
+
+  // skills에 해당하는 문자만 남김
+  const filteredSkillTrees = skill_trees.map((skillTree) => {
+    return [...skillTree].filter((skill) => skills.includes(skill)).join("");
+  });
+
+  // 스킬트리가 skills의 접두사이면 answer + 1
+  filteredSkillTrees.forEach((skillTree) => {
+    if (skills.startsWith(skillTree)) answer += 1;
+  });
+
+  return answer;
+}


### PR DESCRIPTION
요소를 필터링 하는 과정에서 변수명의 혼란이 생길 수 있어 `solution` 함수의 첫 번째 인자인 `skill`을 `skills`로 변경해서 풀었습니다!