### PR TITLE
[PGM] 숫자 변환하기 / Level 2 / 45분

### DIFF
--- a/dongmin/숫자 변환하기.js
+++ b/dongmin/숫자 변환하기.js
@@ -1,0 +1,35 @@
+function solution(x, y, n) {
+  const visited = new Set();
+  const queue = [[y, 0]];
+
+  // queue에서 순서대로 값을 꺼내며 진행
+  while (queue.length > 0) {
+    const [current, count] = queue.shift();
+
+    // 현재의 값이 x와 같아지면 count를 return
+    if (current === x) {
+      return count;
+    }
+
+    // current가 visited에 없는 값이면 visited에 추가
+    // queue에 각각 current - n, current / 2, current / 3 을 한 값을 담음
+    // 단, x보다 값이 작아지거나 나누어 떨어지지 않는 경우 제외
+    if (current > x && !visited.has(current)) {
+      visited.add(current);
+
+      if (current - n >= x) {
+        queue.push([current - n, count + 1]);
+      }
+      if (current % 2 === 0) {
+        queue.push([current / 2, count + 1]);
+      }
+      if (current % 3 === 0) {
+        queue.push([current / 3, count + 1]);
+      }
+    }
+
+    // if문으로 걸러지지 못한 경우 shift()만 진행하고 다음 단계로 진행
+    continue;
+  }
+  return -1;
+}


### PR DESCRIPTION
`BFS`문제임을 알아채고 바로 문제를 풀어서 20분만에 테케를 통과시켰는데 히든테케에서 시간초과가 나는 바람에 시간이 지체됐습니다

처음엔 `x`를 시작점으로 두고 `y`가 될 때까지 접근하면서 `x`가 `y`보다 커지는 경우만 `continue`하는 방식으로 풀었는데 시간초과가 4개나 나올 정도로 효율이 정말 좋지 않았고

다음엔 `y`를 시작점으로 두고 `x`가 될 때까지 접근하면서 `y`가 나누어 떨어지지 않거나 0 미만으로 내려가는 경우는 `queue`에 값을 담지 않는 식으로 시행횟수를 줄여 히든테케 10번만 시간초과되는 수준까지 효율을 올렸습니다

분명 반복 시행되는 부분이 있을거라 생각하고 고민하다가 `visited`로 이미 접근했던 숫자는 다시 계산하지 않는 방법으로 통과했습니다!